### PR TITLE
Make oauth paths relative

### DIFF
--- a/app/models/mautic/connections/oauth2.rb
+++ b/app/models/mautic/connections/oauth2.rb
@@ -5,8 +5,8 @@ module Mautic
       def client
         @client ||= OAuth2::Client.new(client_id, secret, {
           site: url,
-          authorize_url: '/oauth/v2/authorize',
-          token_url: '/oauth/v2/token',
+          authorize_url: 'oauth/v2/authorize',
+          token_url: 'oauth/v2/token',
           raise_errors: false
         })
       end


### PR DESCRIPTION
Mautic gem of master branch would not work in the case that the mautic url is something like `https://foo.com/bar` (i.e. the url with some backslashes).

This problem occurs because the `authorize_url` and `token_url` start with a backslash. Since `client.auth_code.authorize_url(redirect_uri: callback_url)` (or `client.auth_code.get_token(code, redirect_uri: callback_url)`) reduces to `Faraday::Connection#build_url` (see [oauth2 gem](https://github.com/oauth-xx/oauth2/blob/master/lib/oauth2/client.rb#L73)) and `Faraday` initializer ignores all subdirectories of the root url if the given path starts with a backslash, `/bar` in `https://foo.com/bar` is ignored; hence the `authorize_url` becomes `https://foo.com/oauth/v2/...`.

For a path not starting with a backslash, `Faraday` recognizes subdirectories. So, if `authorize_url` is not `/oauth/v2/authorize` but `oauth/v2/authorize`, then the `authorize_url` is `https://foo.com/bar/oauth/v2/...` as expected.

### Summary
`authorize_url` (resp. `token_url`) in `app/models/mautic/connections/oauth2.rb` must be `oauth/v2/authorize` (resp. `oauth/v2/token`), not starting with a backslash.