### PR TITLE
refs #15 add tag collection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
+require:
+  - rubocop-rails
 Rails:
   Enabled: true
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- work with tags on contact
+### Added
+- Tag::Collection for add / remove tag
+
+## [2.3.9] - 2020-07-07
 ### Security
 - Control access to Mautic::ConnectionsController
 ## [2.3.8] - 2020-06-24

--- a/app/models/mautic/contact.rb
+++ b/app/models/mautic/contact.rb
@@ -41,8 +41,9 @@ module Mautic
 
       if source
         self.owner = source['owner'] || {}
+        tags = (source['tags'] || []).map { |t| Mautic::Tag.new(self, t) }.sort_by(&:name)
         self.attributes = {
-          tags: (source['tags'] || []).collect { |t| Mautic::Tag.new(@connection, t) }.sort_by(&:name),
+          tags: Tag::Collection.new(self, *tags),
           doNotContact: source['doNotContact'] || [],
           owner: owner['id'],
         }
@@ -51,7 +52,6 @@ module Mautic
 
     def to_mautic(data = @table)
       data.delete(:doNotContact)
-      data.delete(:tags)
       super(data)
     end
 
@@ -96,7 +96,7 @@ module Mautic
         self.errors = e.errors
       end
 
-      self.errors.blank?
+      errors.blank?
     end
 
     alias add_dnc do_not_contact!

--- a/app/models/mautic/tag.rb
+++ b/app/models/mautic/tag.rb
@@ -1,6 +1,34 @@
 module Mautic
   class Tag < Model
 
+    class Collection < Array
+      attr_reader :model
+
+      # @param [Mautic::Model] model
+      def initialize(model, *several_variants)
+        @model = model
+        @tags_to_remove = []
+        super(several_variants)
+      end
+
+      def <<(item)
+        @model.changed = true
+        item = Tag.new(@model, { tag: item }) if item.is_a?(String)
+        super(item)
+      end
+
+      def remove(item)
+        @model.changed = true
+        item = detect { |t| t.name == item } if item.is_a?(String)
+        @tags_to_remove << "-#{item}"
+        delete item
+      end
+
+      def to_mautic
+        map(&:name) + @tags_to_remove
+      end
+    end
+
     # alias for attribute :tag
     def name
       tag

--- a/lib/mautic/version.rb
+++ b/lib/mautic/version.rb
@@ -1,3 +1,3 @@
 module Mautic
-  VERSION = '2.3.9'
+  VERSION = '2.3.10'
 end

--- a/spec/fixtures/files/contact.json
+++ b/spec/fixtures/files/contact.json
@@ -37,6 +37,10 @@
       {
         "id": 1,
         "tag": "important"
+      },
+      {
+        "id": 2,
+        "tag": "another tag"
       }
     ],
     "doNotContact": [

--- a/spec/models/mautic/contact_spec.rb
+++ b/spec/models/mautic/contact_spec.rb
@@ -185,7 +185,7 @@ module Mautic
         end
 
         it "to_mautic should be values" do
-          expect(mautic_contact.to_mautic).not_to include :tags
+          expect(mautic_contact.to_mautic).to include tags: ["another tag", "important"]
         end
       end
 

--- a/spec/models/mautic/tag_spec.rb
+++ b/spec/models/mautic/tag_spec.rb
@@ -24,5 +24,42 @@ module Mautic
         expect(subject.name).to eq "XX"
       end
     end
+
+    describe Tag::Collection do
+      let(:model) { Model.new(oauth2) }
+      let(:tags) { [Tag.new(model, { tag: "tag1" }), Tag.new(model, { tag: "tag2" })] }
+      subject { described_class.new model, *tags }
+      describe "<<" do
+        context "trigger model changed?" do
+          it "string" do
+            expect { subject << "cipisek" }.to change(model, :changed?).to true
+          end
+          it "Tag instance" do
+            expect {
+              subject << Tag.new(model, { tag: "cipisek" })
+            }.to change(model, :changed?).to true
+          end
+        end
+      end
+
+      describe "#to_mautic" do
+        it "should be array" do
+          expect(subject.to_mautic).to eq %w[tag1 tag2]
+        end
+      end
+
+      describe "#remove" do
+        it "delete tag" do
+          expect { subject.remove("tag1") }.to change(subject, :size).from(2).to 1
+        end
+        it "#to_mautic include -tag1" do
+          expect { subject.remove("tag1") }.to change(subject, :to_mautic).to %w[tag2 -tag1]
+        end
+
+        it "trigger model changed?" do
+          expect { subject.remove("tag1") }.to change(model, :changed?).to true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
fix update tags of contact, add or remove them.
Add Tag::Collection class for manage tags of contact.

Usage:
```ruby
contact.tags # => Array of Mautic::Tag objects
contact.tags << "tagX" # => This build Mautic::Tag instance.
contact.tags.remove "tag1" # => Remove tag1 from collection. In update request it send "-tag1" into mautic for remove = https://developer.mautic.org/#edit-contact
```